### PR TITLE
Added additional settings that seem useful for SVG on the web.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
  
   <groupId>org.jfree</groupId>
   <artifactId>jfreesvg</artifactId>
-  <version>3.1</version>
+  <version>3.2</version>
   <packaging>jar</packaging>
 
   <name>JFreeSVG</name>

--- a/src/main/java/org/jfree/graphics2d/svg/SVGGraphics2D.java
+++ b/src/main/java/org/jfree/graphics2d/svg/SVGGraphics2D.java
@@ -2646,7 +2646,7 @@ public final class SVGGraphics2D extends Graphics2D {
         }
         svg.append("xmlns=\"http://www.w3.org/2000/svg\" ")
            .append("xmlns:xlink=\"http://www.w3.org/1999/xlink\" ")
-           .append("xmlns:jfreesvg=\"http://www.jfree.org/jfreesvg/svg\"");
+           .append("xmlns:jfreesvg=\"http://www.jfree.org/jfreesvg/svg");
         if (printDimensions) {
            svg.append("\" width=\"").append(this.width)
               .append("\" height=\"").append(this.height);


### PR DESCRIPTION
Hi.

I'm generating SVG for the web and need the SVG to be responsive.
I did some research along the way and found that certain properties can be set on the root element in order to make the SVG scale nicely in browsers.

The properties in question are:

- [viewBox](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox)
- [preserveAspectRatio](https://developer.mozilla.org/en/docs/Web/SVG/Attribute/preserveAspectRatio)

I added settings for these two in the SVGGraphics2D class accordingly.

I also found that even when the `viewBox` property is set, an explicit width and height on the SVG can influence responsiveness on the web as described [here](https://css-tricks.com/scale-svg/#article-header-id-2), for example.

For this reason I added a `printDimensions` flag which is true by default but can be disabled so that no dimensions are added to the SVG root element.

Hope these additions are desirable.

Things are documented and basic parameter checks are in place.

Cheers.