### PR TITLE
Performance improvement: omit transformation if it's the identity matrix

### DIFF
--- a/src/main/java/org/jfree/graphics2d/svg/SVGGraphics2D.java
+++ b/src/main/java/org/jfree/graphics2d/svg/SVGGraphics2D.java
@@ -1188,8 +1188,9 @@ public final class SVGGraphics2D extends Graphics2D {
                     .append("\" y2=\"").append(geomDP(l.getY2()))
                     .append("\" ");
             this.sb.append("style=\"").append(strokeStyle()).append("\" ");
-            this.sb.append("transform=\"").append(getSVGTransform(
-                    this.transform)).append("\" ");
+            if (!this.transform.isIdentity())
+            	this.sb.append("transform=\"").append(getSVGTransform(
+            		this.transform)).append("\" ");
             this.sb.append(getClipPathRef());
             this.sb.append("/>");
         } else if (s instanceof Rectangle2D) {
@@ -1203,8 +1204,9 @@ public final class SVGGraphics2D extends Graphics2D {
                     .append("\" ");
             this.sb.append("style=\"").append(strokeStyle())
                     .append("; fill: none").append("\" ");
-            this.sb.append("transform=\"").append(getSVGTransform(
-                    this.transform)).append("\" ");
+            if (!this.transform.isIdentity())
+            	this.sb.append("transform=\"").append(getSVGTransform(
+            		this.transform)).append("\" ");
             this.sb.append(getClipPathRef());
             this.sb.append("/>");
         } else if (s instanceof Ellipse2D) {
@@ -1218,8 +1220,9 @@ public final class SVGGraphics2D extends Graphics2D {
                     .append("\" ");
             this.sb.append("style=\"").append(strokeStyle())
                     .append("; fill: none").append("\" ");
-            this.sb.append("transform=\"").append(getSVGTransform(
-                    this.transform)).append("\" ");
+            if (!this.transform.isIdentity()) 
+            	this.sb.append("transform=\"").append(getSVGTransform(
+            		this.transform)).append("\" ");
             this.sb.append(getClipPathRef());
             this.sb.append("/>");        
         } else if (s instanceof Path2D) {
@@ -1228,8 +1231,9 @@ public final class SVGGraphics2D extends Graphics2D {
             appendOptionalElementIDFromHint(this.sb);
             this.sb.append("style=\"").append(strokeStyle())
                     .append("; fill: none").append("\" ");
-            this.sb.append("transform=\"").append(getSVGTransform(
-                    this.transform)).append("\" ");
+            if (!this.transform.isIdentity()) 
+            	this.sb.append("transform=\"").append(getSVGTransform(
+            		this.transform)).append("\" ");
             this.sb.append(getClipPathRef());
             this.sb.append(">");
             this.sb.append("<path ").append(getSVGPathData(path)).append("/>");
@@ -1264,8 +1268,9 @@ public final class SVGGraphics2D extends Graphics2D {
                     .append("\" height=\"").append(geomDP(r.getHeight()))
                     .append("\" ");
             this.sb.append("style=\"").append(getSVGFillStyle()).append("\" ");
-            this.sb.append("transform=\"").append(getSVGTransform(
-                    this.transform)).append("\" ");
+            if (!this.transform.isIdentity()) 
+            	this.sb.append("transform=\"").append(getSVGTransform(
+            		this.transform)).append("\" ");
             this.sb.append(getClipPathRef());
             this.sb.append("/>");
         } else if (s instanceof Ellipse2D) {
@@ -1278,8 +1283,9 @@ public final class SVGGraphics2D extends Graphics2D {
                     .append("\" ry=\"").append(geomDP(e.getHeight() / 2.0))
                     .append("\" ");
             this.sb.append("style=\"").append(getSVGFillStyle()).append("\" ");
-            this.sb.append("transform=\"").append(getSVGTransform(
-                    this.transform)).append("\" ");
+            if (!this.transform.isIdentity()) 
+            	this.sb.append("transform=\"").append(getSVGTransform(
+            		this.transform)).append("\" ");
             this.sb.append(getClipPathRef());
             this.sb.append("/>");        
         } else if (s instanceof Path2D) {
@@ -1288,8 +1294,9 @@ public final class SVGGraphics2D extends Graphics2D {
             appendOptionalElementIDFromHint(this.sb);
             this.sb.append("style=\"").append(getSVGFillStyle());
             this.sb.append("; stroke: none").append("\" ");
-            this.sb.append("transform=\"").append(getSVGTransform(
-                    this.transform)).append("\" ");
+            if (!this.transform.isIdentity()) 
+            	this.sb.append("transform=\"").append(getSVGTransform(
+            		this.transform)).append("\" ");
             this.sb.append(getClipPathRef());
             this.sb.append(">");
             this.sb.append("<path ").append(getSVGPathData(path)).append("/>");
@@ -1669,7 +1676,8 @@ public final class SVGGraphics2D extends Graphics2D {
                 this.hints.get(SVGHints.KEY_DRAW_STRING_TYPE))) {
             this.sb.append("<g ");
             appendOptionalElementIDFromHint(this.sb);
-            this.sb.append("transform=\"").append(getSVGTransform(
+            if (!this.transform.isIdentity()) 
+            	this.sb.append("transform=\"").append(getSVGTransform(
                     this.transform)).append("\">");
             this.sb.append("<text x=\"").append(geomDP(x))
                     .append("\" y=\"").append(geomDP(y))
@@ -2388,7 +2396,8 @@ public final class SVGGraphics2D extends Graphics2D {
                     img)));
             this.sb.append("\" ");
             this.sb.append(getClipPathRef()).append(" ");
-            this.sb.append("transform=\"").append(getSVGTransform(
+            if (!this.transform.isIdentity()) 
+            	this.sb.append("transform=\"").append(getSVGTransform(
                     this.transform)).append("\" ");            
             this.sb.append("x=\"").append(geomDP(x))
                     .append("\" y=\"").append(geomDP(y))
@@ -2413,7 +2422,8 @@ public final class SVGGraphics2D extends Graphics2D {
             this.sb.append("xlink:href=\"");
             this.sb.append(href).append("\" ");
             this.sb.append(getClipPathRef()).append(" ");
-            this.sb.append("transform=\"").append(getSVGTransform(
+            if (!this.transform.isIdentity()) 
+            	this.sb.append("transform=\"").append(getSVGTransform(
                     this.transform)).append("\" ");
             this.sb.append("x=\"").append(geomDP(x))
                     .append("\" y=\"").append(geomDP(y))


### PR DESCRIPTION
In my project, which generates thousands of svg in a very short amount
of time, transformDP is a major performance killer. This is a pitty
because I do not use transformation matrices (I precompute the
transformations and generate the shapes with the right coordinates
directly).

This patch greatly helps the performance my code, with no rendering
difference for my svg files. In addition, the svg files are much
smaller too.

I eagerly wait for your comments on my change. If you like it, other will come.