### PR TITLE
fix quotes for the transform attribute

### DIFF
--- a/src/main/java/org/jfree/graphics2d/svg/SVGGraphics2D.java
+++ b/src/main/java/org/jfree/graphics2d/svg/SVGGraphics2D.java
@@ -1685,9 +1685,9 @@ public final class SVGGraphics2D extends Graphics2D {
             appendOptionalElementIDFromHint(this.sb);
             if (!this.transform.isIdentity()) {
             	this.sb.append("transform=\"").append(getSVGTransform(
-                    this.transform));
+                    this.transform)).append("\"");
             }
-            this.sb.append("\">");
+            this.sb.append(">");
             this.sb.append("<text x=\"").append(geomDP(x))
                     .append("\" y=\"").append(geomDP(y))
                     .append("\"");


### PR DESCRIPTION
The commit 3d00adc9091bd0e03da159dccf90aca36c020449 breaks the SVG when `!this.transform.isIdentity()` is false (it emits `<g ">`). ping: @mquinson  #15