### PR TITLE
Add possibilites for anchors

### DIFF
--- a/src/main/java/org/jfree/svg/SVGGraphics2D.java
+++ b/src/main/java/org/jfree/svg/SVGGraphics2D.java
@@ -994,9 +994,10 @@ public final class SVGGraphics2D extends Graphics2D {
                     this.sb.append("<a href='").append(link).append('\'');
                     for (final Entry<?, ?> entry : hintValueMap.entrySet()) {
                         if (!entry.getKey().equals(href)) {
-                            this.sb.append(' ').append(entry.getKey()).append("='");
-                            this.sb..append(SVGUtils.escapeForXML(String.valueOf(entry.getValue()))).append('\'');
+                            continue;
 			}
+                        this.sb.append(' ').append(entry.getKey()).append("='");
+                        this.sb..append(SVGUtils.escapeForXML(String.valueOf(entry.getValue()))).append('\'');
                     }
                     this.sb.append('>');
 		}

--- a/src/main/java/org/jfree/svg/SVGGraphics2D.java
+++ b/src/main/java/org/jfree/svg/SVGGraphics2D.java
@@ -984,24 +984,25 @@ public final class SVGGraphics2D extends Graphics2D {
             this.sb.append(SVGUtils.escapeForXML(String.valueOf(hintValue)));
             this.sb.append("</title>");
         } else if (SVGHints.KEY_BEGIN_ANCHOR.equals(hintKey) && hintValue != null) {
-			if (hintValue instanceof URL) {
-				this.sb.append("<a href='").append(hintValue.toString()).append("'>");
-		    } else if (hintValue instanceof Map) {
-				final String href = "href";
-				Map<?, ?> hintValueMap = (Map<?, ?>) hintValue;
-				String link = hintValueMap.get(href).toString();
-				if (link != null) {
-					this.sb.append("<a href='").append(link).append('\'');
-					for (final Entry<?, ?> entry : hintValueMap.entrySet()) {
-						if (!entry.getKey().equals(href))
-							this.sb.append(' ').append(entry.getKey()).append("='")
-									.append(SVGUtils.escapeForXML(String.valueOf(entry.getValue()))).append('\'');
-					}
-					this.sb.append('>');
-				}
+            if (hintValue instanceof URL) {
+                this.sb.append("<a href='").append(hintValue.toString()).append("'>");
+            } else if (hintValue instanceof Map) {
+                final String href = "href";
+                Map<?, ?> hintValueMap = (Map<?, ?>) hintValue;
+                String link = hintValueMap.get(href) != null ? hintValueMap.get(href).toString() : null;
+                if (link != null) {
+                    this.sb.append("<a href='").append(link).append('\'');
+                    for (final Entry<?, ?> entry : hintValueMap.entrySet()) {
+                        if (!entry.getKey().equals(href)) {
+                            this.sb.append(' ').append(entry.getKey()).append("='");
+                            this.sb..append(SVGUtils.escapeForXML(String.valueOf(entry.getValue()))).append('\'');
 			}
-		} else if (SVGHints.KEY_END_ANCHOR.equals(hintKey)) {
-			this.sb.append("</a>");
+                    }
+                    this.sb.append('>');
+		}
+	    }
+	} else if (SVGHints.KEY_END_ANCHOR.equals(hintKey)) {
+	    this.sb.append("</a>");
         } else {
             this.hints.put(hintKey, hintValue);
         }

--- a/src/main/java/org/jfree/svg/SVGGraphics2D.java
+++ b/src/main/java/org/jfree/svg/SVGGraphics2D.java
@@ -983,6 +983,25 @@ public final class SVGGraphics2D extends Graphics2D {
             this.sb.append("<title>");
             this.sb.append(SVGUtils.escapeForXML(String.valueOf(hintValue)));
             this.sb.append("</title>");
+        } else if (SVGHints.KEY_BEGIN_ANCHOR.equals(hintKey) && hintValue != null) {
+			if (hintValue instanceof URL) {
+				this.sb.append("<a href='").append(hintValue.toString()).append("'>");
+		    } else if (hintValue instanceof Map) {
+				final String href = "href";
+				Map<?, ?> hintValueMap = (Map<?, ?>) hintValue;
+				String link = hintValueMap.get(href).toString();
+				if (link != null) {
+					this.sb.append("<a href='").append(link).append('\'');
+					for (final Entry<?, ?> entry : hintValueMap.entrySet()) {
+						if (!entry.getKey().equals(href))
+							this.sb.append(' ').append(entry.getKey()).append("='")
+									.append(SVGUtils.escapeForXML(String.valueOf(entry.getValue()))).append('\'');
+					}
+					this.sb.append('>');
+				}
+			}
+		} else if (SVGHints.KEY_END_ANCHOR.equals(hintKey)) {
+			this.sb.append("</a>");
         } else {
             this.hints.put(hintKey, hintValue);
         }

--- a/src/main/java/org/jfree/svg/SVGHints.java
+++ b/src/main/java/org/jfree/svg/SVGHints.java
@@ -186,6 +186,33 @@ public final class SVGHints {
      */
     public static final SVGHints.Key KEY_ELEMENT_TITLE = new SVGHints.Key(6);
 
+    	/**
+	 * Hint key that informs the {@code SVGGraphics2D} that the caller would like to
+	 * begin a new anchor element ({@code <a href='...'>}). The hint value is
+	 * either:
+	 * <ul>
+	 * <li>a {@code URL} that will be used as the value of the {@code href}
+	 * attribute for the anchor; or</li>
+	 * <li>a {@code Map} instance containing arbitrary attribute values for the
+	 * anchor. At least the key {@code href} has to be part of the map. If it is
+	 * not, the anchor won't be opened.</li>
+	 * </ul>
+	 * After opening the new anchor the hint is cleared and it is the caller's
+	 * responsibility to close the anchor later using
+	 * {@link SVGHints#KEY_END_ANCHOR}. Anchors can't be nested.
+	 * 
+	 * @since 5.8
+	 */
+	public static final SVGHints.Key KEY_BEGIN_ANCHOR = new SVGHints.Key(8);
+
+	/**
+	 * Hint key that informs the {@code SVGGraphics2D} that the caller would like to
+	 * close a previously opened anchor element. The hint value is ignored.
+	 * 
+	 * @since 5.8
+	 */
+	public static final SVGHints.Key KEY_END_ANCHOR = new SVGHints.Key(9);
+
     /**
      * The key for the hint that controls whether strings are rendered as
      * characters or vector graphics (implemented using {@code TextLayout}).  


### PR DESCRIPTION
Proposal to add anchors to SVG graphs (`<a href="...">`). It is similar like groups as usually you'll put a link on whole parts of SVG elements.

I didn't add the possibilities to "externalize" the creation of anchors (as it is possible for groups and titles). But of course it's open to the maintainer to add that too. I hope that's in the sense of the project.